### PR TITLE
Force just the tag name and not the extra items

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = {
       _command('git rev-parse --abbrev-ref HEAD', cb)
     }
   , tag : function (cb) { 
-      _command('git describe --always --tag', cb)
+      _command('git describe --always --tag --abbrev=0', cb)
     }
   , log : function (cb) { 
       _command('git log --no-color --pretty=format:\'[ "%H", "%s", "%cr", "%an" ],\' --abbrev-commit', function (str) {


### PR DESCRIPTION
.tag() does perform expected operation when current commit is not the tag ref. Instead it returns commits since tag ref and current short commit. --abbrev=0 fixes this.
