### PR TITLE
.log doesn't properly escape quotes

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,7 @@
 var exec = require('child_process').exec
+  , async = require('async')
+  , delimiter = '|##|^'
+  , eol = '*||*}';
 
 function _command (cmd, cb) {
   exec(cmd, function (err, stdout, stderr) {
@@ -20,9 +23,13 @@ module.exports = {
       _command('git describe --always --tag --abbrev=0', cb)
     }
   , log : function (cb) { 
-      _command('git log --no-color --pretty=format:\'[ "%H", "%s", "%cr", "%an" ],\' --abbrev-commit', function (str) {
+      _command('git log --no-color --pretty=format:"%H'+delimiter+'%s'+delimiter+'%cr'+delimiter+'%an'+eol+'" --abbrev-commit', function (str) {
         str = str.substr(0, str.length-1)
-        cb(JSON.parse('[' + str + ']'))
+        async.mapSeries(str.split(eol), function(line, next) {
+          next(null, line.split(delimiter));
+        }, function(err, log) {
+          cb(log);
+        });
       })
     }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   "directories" : {
     "example" : "example"
   },
-  "dependencies" : {},
+  "dependencies" : {
+    "async": "*"
+  },
   "devDependencies" : {},
   "scripts" : {},
   "repository" : {


### PR DESCRIPTION
## Merge request for #4
# Summary

.log doesn't properly escape quotes causing the following to occur:

```
co Ceppi" ],[ "81735deeacf3c050b1f73e8923f785cb6c5f5e2d", "Tweaked "messages""
                                                                    ^
SyntaxError: Unexpected token m
    at Object.parse (native)
    at module.exports.log (/home/marco/Projects/ondina/control-panel/node_modules/git-rev/index.js:25:17)
    at /home/marco/Projects/ondina/control-panel/node_modules/git-rev/index.js:5:5
    at ChildProcess.exithandler (child_process.js:538:7)
    at ChildProcess.EventEmitter.emit (events.js:96:17)
    at maybeClose (child_process.js:638:16)
    at Socket.ChildProcess.spawn.stdin (child_process.js:815:11)
    at Socket.EventEmitter.emit (events.js:93:17)
    at Socket._destroy.destroyed (net.js:357:10)
    at process.startup.processNextTick.process._tickCallback (node.js:244:9)
```
