### PR TITLE
fix for launching outside of project dir

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var exec = require('child_process').exec
 
 function _command (cmd, cb) {
-  exec(cmd, function (err, stdout, stderr) {
+  exec(cmd, { cwd: __dirname }, function (err, stdout, stderr) {
     cb(stdout.split('\n').join(''))
   })
 }


### PR DESCRIPTION
If the process was launched outside of the project dir, git-rev would not properly identify the project git id because it would default to CWD (which is not current). This changes git-rev to use the `__dirname` of the file which is more likely to reside inside of the repo the user wants to id.
