### PR TITLE
allow testing git repo outside of project root

### DIFF
--- a/example/nested.sh
+++ b/example/nested.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+pwd
+export ORIGINAL=$(pwd)
+TESTDIR=/tmp/outside-git-rev
+mkdir -p $TESTDIR
+cp $ORIGINAL/index.js $TESTDIR/index.js
+cp $ORIGINAL/example/outside.js $TESTDIR/outside.js
+(
+  cd $TESTDIR
+  echo "inside" $TESTDIR
+  pwd
+  ORIGINAL=$ORIGINAL node outside.js
+)
+rm -Rfv $TESTDIR
+

--- a/example/outside.js
+++ b/example/outside.js
@@ -1,0 +1,11 @@
+
+var git = require('./index');
+var cwd = process.env.ORIGINAL;
+console.log('dir', __dirname);
+console.log('original', cwd);
+git.cwd(cwd);
+git.short(function (str) {
+  console.log('short', str)
+
+})
+

--- a/index.js
+++ b/index.js
@@ -1,13 +1,20 @@
 var exec = require('child_process').exec
 
 function _command (cmd, cb) {
-  exec(cmd, { cwd: __dirname }, function (err, stdout, stderr) {
+  exec(cmd, { cwd: cwd( ) }, function (err, stdout, stderr) {
     cb(stdout.split('\n').join(''))
   })
 }
 
-module.exports = { 
-    short : function (cb) { 
+function cwd (_) {
+  if (_) { cwd.directory = _; }
+  return cwd.directory;
+}
+cwd.directory = __dirname;
+
+module.exports = {
+    cwd: cwd
+  , short : function (cb) {
       _command('git rev-parse --short HEAD', cb)
     }
   , long : function (cb) {

--- a/index.js
+++ b/index.js
@@ -10,16 +10,16 @@ module.exports = {
     short : function (cb) { 
       _command('git rev-parse --short HEAD', cb)
     }
-  , long : function (cb) { 
+  , long : function (cb) {
       _command('git rev-parse HEAD', cb)
     }
-  , branch : function (cb) { 
+  , branch : function (cb) {
       _command('git rev-parse --abbrev-ref HEAD', cb)
     }
-  , tag : function (cb) { 
+  , tag : function (cb) {
       _command('git describe --always --tag --abbrev=0', cb)
     }
-  , log : function (cb) { 
+  , log : function (cb) {
       _command('git log --no-color --pretty=format:\'[ "%H", "%s", "%cr", "%an" ],\' --abbrev-commit', function (str) {
         str = str.substr(0, str.length-1)
         cb(JSON.parse('[' + str + ']'))


### PR DESCRIPTION
I want to use this module to help report version of my software running in M$'s Azure.  Azure is a pretty nice environment, but the `wwwroot` (where the code was deployed and runs as the `CWD`), is actually a sibling directory to the git repo root, `repository`.  This patch allows specifying an alternate git root directory to hep with cases like that.
