### PR TITLE
implemented exactTag command

### DIFF
--- a/example/simple.js
+++ b/example/simple.js
@@ -35,3 +35,6 @@ git.log(function (array) {
   //     '2 days ago',
   //     'Thomas Blobaum' ] ]
 })
+git.exactTag(function(str){
+  console.log('exactTag',str)
+})

--- a/index.js
+++ b/index.js
@@ -6,23 +6,33 @@ function _command (cmd, cb) {
   })
 }
 
-module.exports = { 
-    short : function (cb) { 
+module.exports = {
+    short : function (cb) {
       _command('git rev-parse --short HEAD', cb)
     }
-  , long : function (cb) { 
+  , long : function (cb) {
       _command('git rev-parse HEAD', cb)
     }
-  , branch : function (cb) { 
+  , branch : function (cb) {
       _command('git rev-parse --abbrev-ref HEAD', cb)
     }
-  , tag : function (cb) { 
+  , tag : function (cb) {
       _command('git describe --always --tag --abbrev=0', cb)
     }
-  , log : function (cb) { 
+  , log : function (cb) {
       _command('git log --no-color --pretty=format:\'[ "%H", "%s", "%cr", "%an" ],\' --abbrev-commit', function (str) {
         str = str.substr(0, str.length-1)
         cb(JSON.parse('[' + str + ']'))
       })
     }
+  , exactTag: function(cb){
+    _command('git describe --exact-match --tags HEAD',function(str){
+      if (str){
+        cb(str)
+      }else{
+        cb(undefined)
+      }
+
+    })
+  }
 }


### PR DESCRIPTION
in relation to issue #21 i implemented a new function: `exactTag` which will return the name of the tag matching HEAD. If no tag matches, undefined is returned.

The command used to retrieve the tag is the following

``` bash
git describe --exact-match --tags HEAD
```

It will write to stdout the name of tag, or an error to stderr when no tag matches.
